### PR TITLE
Add Ace-Jinwoo Nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Ace-Jinwoo
+# Ace-Jinwoo OS
+
+This repository provides a minimal Nix flake that builds an Athena OS based system customised with the **Ace‑Jinwoo** theme.
+
+The configuration reuses [Athena OS](https://github.com/Athena-OS/athena-nix) modules and applies a custom theme defined in `modules/ace-jinwoo-theme`.
+
+## Getting Started
+
+1. Ensure [Nix](https://nixos.org/) is installed.
+2. Clone this repository:
+   ```bash
+   git clone <this repo url> ace-jinwoo
+   cd ace-jinwoo
+   ```
+3. Build or install the system using `nixos-rebuild`:
+   ```bash
+   sudo nixos-rebuild switch --flake .#acejinwoo --impure
+   ```
+   The `--impure` flag allows using your local `hardware-configuration.nix`.
+
+The default user configured is `ace` with the Ace-Jinwoo themed desktop.
+
+## Customisation
+
+Edit `configuration.nix` to adjust options such as desktop environment or packages. The Ace-Jinwoo theme itself can be tweaked in `modules/ace-jinwoo-theme/default.nix`.

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,19 @@
+{ config, pkgs, ... }:
+{
+  imports = [ ];
+
+  athena = {
+    enable = true;
+    baseConfiguration = true;
+    baseSoftware = true;
+    baseLocale = true;
+    homeManagerUser = "ace";
+    desktopManager = "gnome";
+    displayManager = "sddm";
+    mainShell = "fish";
+    terminal = "kitty";
+    browser = "firefox";
+    bootloader = "systemd";
+    theme = "ace-jinwoo";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Ace-Jinwoo customized Athena OS configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    athena.url = "github:Athena-OS/athena-nix";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, athena, home-manager }:
+    let
+      system = "x86_64-linux";
+    in {
+      nixosConfigurations = {
+        acejinwoo = nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [
+            athena.nixosModules.athena
+            home-manager.nixosModules.home-manager
+            ./configuration.nix
+            ./modules/ace-jinwoo-theme/default.nix
+          ];
+          specialArgs = { inherit athena; };
+        };
+      };
+    };
+}

--- a/modules/ace-jinwoo-theme/default.nix
+++ b/modules/ace-jinwoo-theme/default.nix
@@ -1,0 +1,53 @@
+{ lib, pkgs, config, ... }:
+let
+  # Ace-Jinwoo theme components. Adjust packages as desired.
+  theme-components = {
+    gtk-theme = "Tokyonight-Dark";
+    icon-theme = "Papirus-Dark";
+    cursor-theme = "Bibata-Modern-Classic";
+    background = "arch-ascii.png"; # shipped by athena-blue-base
+  };
+  gtkTheme = "${theme-components.gtk-theme}";
+  gtkIconTheme = "${theme-components.icon-theme}";
+  gtkCursorTheme = "${theme-components.cursor-theme}";
+in {
+  config = lib.mkIf (config.athena.theme == "ace-jinwoo") {
+    athena.theme-components = theme-components;
+
+    environment.systemPackages = with pkgs; [
+      (callPackage (athena + "/nixos/pkgs/themes/athena-blue-base/package.nix") { })
+    ];
+
+    home-manager.users.${config.athena.homeManagerUser} = { pkgs, ... }: {
+      home.sessionVariables.GTK_THEME = gtkTheme;
+      gtk = {
+        enable = true;
+        gtk3.extraConfig.gtk-decoration-layout = "menu:";
+        theme = {
+          name = gtkTheme;
+          package = pkgs.tokyonight-gtk-theme.override {
+            colorVariants = [ "dark" ];
+            tweakVariants = [ "macos" ];
+          };
+        };
+        iconTheme = {
+          name = gtkIconTheme;
+          package = pkgs.papirus-icon-theme;
+        };
+        cursorTheme = {
+          name = gtkCursorTheme;
+          package = pkgs.bibata-cursors;
+        };
+      };
+      programs = {
+        kitty.themeFile = "tokyo_night_storm";
+        vscode = {
+          profiles.default.extensions = with pkgs.vscode-extensions; [
+            enkia.tokyo-night
+          ];
+          profiles.default.userSettings = { "workbench.colorTheme" = "Tokyo Night Storm"; };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add Nix flake to build Ace-Jinwoo OS on top of athena-nix
- create example configuration
- implement Ace-Jinwoo theme module
- document usage in README

## Testing
- `nix --version` *(fails: command not found)*

------